### PR TITLE
Fixes Media display without SSL in Android 9 (Pie)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
             android:icon="@mipmap/ic_launcher"
             android:label="@string/app_name"
             android:supportsRtl="true"
+            android:usesCleartextTraffic="true"
             android:theme="@style/AppTheme">
         <receiver
                 android:name=".Receiver"


### PR DESCRIPTION
This one fixes issue #21 #20 #12 , because they all belong to http on Pie - which needs the cleartext allowance